### PR TITLE
Fix: Remove blocking sleep to prevent worker timeout tr...

### DIFF
--- a/app.py
+++ b/app.py
@@ -54,7 +54,7 @@ def test3():
 @app.route('/test4')
 def test4():
     while True:
-        time.sleep(1)
+        # time.sleep(1)  # Removed blocking call
         print("Memory leak")
     return jsonify({'message': 'memory leak'}), 200 
 


### PR DESCRIPTION

# Auto Fix Report

> Created at: 2025-05-11 02:12:43

## Error Log

```shell
Memory leak
[2025-05-11 02:09:44 +0000] [1] [CRITICAL] WORKER TIMEOUT (pid:21)
[2025-05-11 02:09:44 +0000] [21] [ERROR] Error handling request /test4
Traceback (most recent call last):
  File "/usr/local/lib/python3.11/site-packages/gunicorn/workers/sync.py", line 134, in handle
    self.handle_request(listener, req, client, addr)
  File "/usr/local/lib/python3.11/site-packages/gunicorn/workers/sync.py", line 177, in handle_request
    respiter = self.wsgi(environ, resp.start_response)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/app/.local/lib/python3.11/site-packages/flask/app.py", line 1536, in __call__
    return self.wsgi_app(environ, start_response)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/app/.local/lib/python3.11/site-packages/flask/app.py", line 1511, in wsgi_app
    response = self.full_dispatch_request()
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/app/.local/lib/python3.11/site-packages/flask/app.py", line 917, in full_dispatch_request
    rv = self.dispatch_request()
         ^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/app/.local/lib/python3.11/site-packages/flask/app.py", line 902, in dispatch_request
    return self.ensure_sync(self.view_functions[rule.endpoint])(**view_args)  # type: ignore[no-any-return]
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/app.py", line 57, in test4
    time.sleep(1)
  File "/usr/local/lib/python3.11/site-packages/gunicorn/workers/base.py", line 204, in handle_abort
    sys.exit(1)
SystemExit: 1
[2025-05-11 02:09:44 +0000] [21] [INFO] Worker exiting (pid: 21)
[2025-05-11 02:09:44 +0000] [22] [INFO] Booting worker with pid: 22
```

## Error Analysis

Remove blocking sleep to prevent worker timeout triggers

## Code Changes


- .sandbox/1e88d6c4535d94fd2f9622d1b73e1833d185e7efc6650f30b3ee0f3d56f66d34/src/app.py:57: Remove blocking sleep to prevent worker timeout triggers

## Analysis Details

Agent Model: deepseek-reasoner

```json
[
  {
    "id": "1e88d6c4535d94fd2f9622d1b73e1833d185e7efc6650f30b3ee0f3d56f66d34",
    "thought": "The error indicates a worker timeout occurring during a sleep call. The 1-second sleep in the request handler is causing Gunicorn sync worker to exceed timeout thresholds, leading to worker termination. Need to address the blocking operation causing timeout.",
    "action": "FIX",
    "details": {
      "explanation": "Long blocking operations in request handlers cause worker timeouts. Replace synchronous sleep with proper asynchronous handling or eliminate unnecessary delays.",
      "inspections": [
        {
          "file_path": ".sandbox/1e88d6c4535d94fd2f9622d1b73e1833d185e7efc6650f30b3ee0f3d56f66d34/src/app.py",
          "line": 57
        }
      ],
      "code_changes": [
        {
          "file_path": ".sandbox/1e88d6c4535d94fd2f9622d1b73e1833d185e7efc6650f30b3ee0f3d56f66d34/src/app.py",
          "line": 57,
          "old_content": "        time.sleep(1)",
          "new_content": "        # time.sleep(1)  # Removed blocking call",
          "explanation": "Remove blocking sleep to prevent worker timeout triggers",
          "type_compatibility": "Change maintains void function behavior, preserves return type consistency"
        }
      ],
      "tests": "1. Load test /test4 endpoint under concurrent requests\n2. Monitor worker stability with metrics (memory usage, response times)\n3. Verify timeout errors no longer occur",
      "prevention": "1. Avoid long blocking operations in request handlers\n2. Use task queues (Celery) for background processes\n3. Implement async workers (gevent)\n4. Add request timeouts in application layer\n5. Monitor worker metrics with Prometheus/Grafana"
    },
    "next": "TEST"
  }
]
```

### Timing

```shell

Created at 2025-05-11 02:09:45
Worker start at 2025-05-11 02:09:46
Queue wait time 255.48ms (0.1%)
Prepare time 760.49ms (0.4%)
Agent time 176032.35ms (99.6%)
Repo time 0.36ms (0.0%)
Total time 176793.23ms (100.0%)

```

