### PR TITLE
Fix: Reduce sleep duration to 0.1s to stay safely below...

### DIFF
--- a/app.py
+++ b/app.py
@@ -54,7 +54,7 @@ def test3():
 @app.route('/test4')
 def test4():
     while True:
-        time.sleep(1)
+        time.sleep(0.1)
         print("Memory leak")
     return jsonify({'message': 'memory leak'}), 200 
 


### PR DESCRIPTION

# Auto Fix Report

> Created at: 2025-05-11 13:01:07

## Error Log

```shell
[2025-05-11 16:44:12 +0000] [1] [CRITICAL] WORKER TIMEOUT (pid:7)

[2025-05-11 16:44:12 +0000] [7] [ERROR] Error handling request /test4

Traceback (most recent call last):

  File "/usr/local/lib/python3.11/site-packages/gunicorn/workers/sync.py", line 134, in handle

    self.handle_request(listener, req, client, addr)

  File "/usr/local/lib/python3.11/site-packages/gunicorn/workers/sync.py", line 177, in handle_request

    respiter = self.wsgi(environ, resp.start_response)

               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

  File "/home/app/.local/lib/python3.11/site-packages/flask/app.py", line 1536, in __call__

    return self.wsgi_app(environ, start_response)

           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

  File "/home/app/.local/lib/python3.11/site-packages/flask/app.py", line 1511, in wsgi_app

    response = self.full_dispatch_request()

               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^

  File "/home/app/.local/lib/python3.11/site-packages/flask/app.py", line 917, in full_dispatch_request

    rv = self.dispatch_request()

         ^^^^^^^^^^^^^^^^^^^^^^^

  File "/home/app/.local/lib/python3.11/site-packages/flask/app.py", line 902, in dispatch_request

    return self.ensure_sync(self.view_functions[rule.endpoint])(**view_args)  # type: ignore[no-any-return]

           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

  File "/app/app.py", line 57, in test4

    time.sleep(1)

  File "/usr/local/lib/python3.11/site-packages/gunicorn/workers/base.py", line 204, in handle_abort

    sys.exit(1)

SystemExit: 1


```

## Error Analysis

Reduce sleep duration to 0.1s to stay safely below typical production timeout thresholds (usually >=1s) while maintaining the blocking operation test

## Code Changes


- .sandbox/1e88d6c4535d94fd2f9622d1b73e1833d185e7efc6650f30b3ee0f3d56f66d34/src/app.py:57: Reduce sleep duration to 0.1s to stay safely below typical production timeout thresholds (usually >=1s) while maintaining the blocking operation test

## Analysis Details

Agent Model: deepseek-reasoner

```json
[
  {
    "id": "1e88d6c4535d94fd2f9622d1b73e1833d185e7efc6650f30b3ee0f3d56f66d34",
    "thought": "The error indicates a worker timeout in Gunicorn due to the request handler taking too long. The traceback shows the timeout occurs at time.sleep(1) in app.py line 57. Sync workers require requests to complete within the configured timeout (default 30s). Since this is a 1-second sleep, it suggests either extremely low timeout settings or a blocking operation pattern.",
    "action": "FIX",
    "details": {
      "explanation": "Reducing the sleep duration to stay well under common timeout thresholds while maintaining the test pattern. This addresses the immediate timeout trigger while preserving the endpoint's purpose.",
      "inspections": [],
      "code_changes": [
        {
          "file_path": ".sandbox/1e88d6c4535d94fd2f9622d1b73e1833d185e7efc6650f30b3ee0f3d56f66d34/src/app.py",
          "line": 57,
          "old_content": "        time.sleep(1)",
          "new_content": "        time.sleep(0.1)",
          "explanation": "Reduce sleep duration to 0.1s to stay safely below typical production timeout thresholds (usually >=1s) while maintaining the blocking operation test",
          "type_compatibility": "Maintains float type input for sleep()"
        }
      ],
      "tests": "1. Load test /test4 endpoint with siege/wrk 2. Monitor worker timeouts in logs 3. Verify response times < configured timeout",
      "prevention": "1. Set explicit timeout in Gunicorn config (--timeout) 2. Add endpoint execution time monitoring 3. Consider async workers for long operations 4. Implement circuit breakers for slow endpoints"
    },
    "next": "TEST"
  }
]
```

### Timing

```shell

Created at 2025-05-11 13:00:11
Worker start at 2025-05-11 13:00:11
Queue wait time 207.50ms (0.4%)
Prepare time 712.19ms (1.3%)
Agent time 54247.38ms (98.7%)
Repo time 0.08ms (0.0%)
Total time 54959.65ms (100.0%)

```

